### PR TITLE
Upgrade to psr/cache:^3 to allow Symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "minimum-stability": "stable",
   "license": "MIT",
   "require": {
-    "psr/cache": "^1.0 | ^2.0",
-    "php": "^7.3 | ^8.0",
+    "psr/cache": "^1.0 | ^2.0 | ^3.0",
+    "php": "^8.0",
     "rikudou/clock": "^1.0",
     "psr/simple-cache": "^1.0",
     "async-aws/dynamo-db": "^1.0"

--- a/src/DynamoCacheItem.php
+++ b/src/DynamoCacheItem.php
@@ -68,29 +68,32 @@ final class DynamoCacheItem implements CacheItemInterface
         $this->set($value);
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function get()
+    public function get(): mixed
     {
         return $this->encoder->decode($this->value);
     }
 
-    public function isHit()
+    public function isHit(): bool
     {
         return $this->isHit && ($this->clock->now() < $this->expiresAt || $this->expiresAt === null);
     }
 
-    public function set($value)
+    public function set($value): static
     {
         $this->value = $this->encoder->encode($value);
 
         return $this;
     }
 
-    public function expiresAt($expiration)
+    /**
+     * @param ?\DateTimeInterface $expiration
+     */
+    public function expiresAt($expiration): static
     {
         if ($expiration === null) {
             $this->expiresAt = null;
@@ -103,7 +106,10 @@ final class DynamoCacheItem implements CacheItemInterface
         return $this;
     }
 
-    public function expiresAfter($time)
+    /**
+     * @param int|\DateInterval|null $time
+     */
+    public function expiresAfter($time): static
     {
         if ($time === null) {
             $this->expiresAt = null;

--- a/src/DynamoDbCache.php
+++ b/src/DynamoDbCache.php
@@ -124,7 +124,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return DynamoCacheItem
      */
-    public function getItem($key)
+    public function getItem($key): CacheItemInterface
     {
         if ($exception = $this->getExceptionForInvalidKey($this->getKey($key))) {
             throw $exception;
@@ -173,7 +173,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return DynamoCacheItem[]
      */
-    public function getItems(array $keys = [])
+    public function getItems(array $keys = []): iterable
     {
         $keys = array_map(function ($key) {
             if ($exception = $this->getExceptionForInvalidKey($this->getKey($key))) {
@@ -248,7 +248,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function hasItem($key)
+    public function hasItem($key): bool
     {
         return $this->getItem($key)->isHit();
     }
@@ -256,7 +256,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
     /**
      * @return false
      */
-    public function clear()
+    public function clear(): bool
     {
         return false;
     }
@@ -269,7 +269,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
         if ($key instanceof DynamoCacheItem) {
             $key = $key->getKey();
@@ -304,7 +304,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         $keys = array_map(function ($key) {
             if ($exception = $this->getExceptionForInvalidKey($this->getKey($key))) {
@@ -338,7 +338,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         $item = $this->converter->convert($item);
         if ($exception = $this->getExceptionForInvalidKey($item->getKey())) {
@@ -379,7 +379,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         if ($exception = $this->getExceptionForInvalidKey($item->getKey())) {
             throw $exception;
@@ -396,7 +396,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
      *
      * @return bool
      */
-    public function commit()
+    public function commit(): bool
     {
         $result = true;
         foreach ($this->deferred as $key => $item) {
@@ -479,7 +479,7 @@ final class DynamoDbCache implements CacheItemPoolInterface, CacheInterface
                 }
 
                 return $default;
-            }, $this->getItems($this->iterableToArray($keys)))
+            }, $this->iterableToArray($this->getItems($this->iterableToArray($keys))))
         );
         assert(is_array($result));
 

--- a/tests/Converter/DefaultCacheItemConverterTest.php
+++ b/tests/Converter/DefaultCacheItemConverterTest.php
@@ -59,32 +59,32 @@ final class DefaultCacheItemConverterTest extends TestCase
     private function createBasicCacheItem()
     {
         return new class implements CacheItemInterface {
-            public function getKey()
+            public function getKey(): string
             {
                 return 'test';
             }
 
-            public function get()
+            public function get(): mixed
             {
                 return 'test';
             }
 
-            public function isHit()
+            public function isHit(): bool
             {
                 return true;
             }
 
-            public function set($value)
+            public function set(mixed $value): static
             {
                 return $this;
             }
 
-            public function expiresAt($expiration)
+            public function expiresAt($expiration): static
             {
                 return $this;
             }
 
-            public function expiresAfter($time)
+            public function expiresAfter($time): static
             {
                 return $this;
             }

--- a/tests/DynamoDbCacheTest.php
+++ b/tests/DynamoDbCacheTest.php
@@ -1255,30 +1255,34 @@ final class DynamoDbCacheTest extends TestCase
     private function getEmptyBaseCacheItem()
     {
         return new class implements CacheItemInterface {
-            public function getKey()
+            public function getKey(): string
             {
                 return 'test';
             }
 
-            public function get()
+            public function get(): mixed
             {
+                return 'test';
             }
 
-            public function isHit()
+            public function isHit(): bool
             {
                 return true;
             }
 
-            public function set($value)
+            public function set($value): static
             {
+                return $this;
             }
 
-            public function expiresAt($expiration)
+            public function expiresAt($expiration): static
             {
+                return $this;
             }
 
-            public function expiresAfter($time)
+            public function expiresAfter($time): static
             {
+                return $this;
             }
         };
     }

--- a/tests/Encoder/JsonItemEncoderTest.php
+++ b/tests/Encoder/JsonItemEncoderTest.php
@@ -87,7 +87,7 @@ final class JsonItemEncoderTest extends TestCase
     private function getJsonSerializableObject()
     {
         return new class implements JsonSerializable {
-            public function jsonSerialize()
+            public function jsonSerialize(): mixed
             {
                 return [
                     'key1' => 'value1',


### PR DESCRIPTION
This PR allows to use psr/cache:^3, which is needed for Symfony 6.x compatibility.

Most notable change is the change of requirement for php, from `^7.3 | ^8.0` to `^8.0`. I guess this probably mean releasing a new major version.

Thank you for your library, it is really useful when using AWS, as they have a generous free tier in DynamoDb