### PR TITLE
Fix implicit nullable

### DIFF
--- a/src/Converter/DefaultCacheItemConverter.php
+++ b/src/Converter/DefaultCacheItemConverter.php
@@ -15,7 +15,7 @@ final class DefaultCacheItemConverter implements CacheItemConverterInterface
 
     private ClockInterface $clock;
 
-    public function __construct(?CacheItemEncoderInterface $encoder = null, ClockInterface $clock = null)
+    public function __construct(?CacheItemEncoderInterface $encoder = null, ?ClockInterface $clock = null)
     {
         if ($encoder === null) {
             $encoder = new SerializeItemEncoder();


### PR DESCRIPTION
Fixes PHP 8.4 deprecation notice:

```
Rikudou\DynamoDbCache\Converter\DefaultCacheItemConverter::__construct(): Implicitly marking parameter $clock as nullable is deprecated, the explicit nullable type must be used instead
```